### PR TITLE
release: 이슈 생성 기능 릴리즈

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@radix-ui/react-checkbox": "^1.1.5",
     "@radix-ui/react-dialog": "^1.1.7",
+    "@radix-ui/react-label": "^2.1.3",
     "@radix-ui/react-slot": "^1.2.0",
     "@radix-ui/react-visually-hidden": "^1.1.3",
     "@tailwindcss/vite": "^4.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-checkbox':
+        specifier: ^1.1.5
+        version: 1.1.5(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-dialog':
         specifier: ^1.1.7
         version: 1.1.7(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-label':
+        specifier: ^2.1.3
+        version: 2.1.3(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-slot':
         specifier: ^1.2.0
         version: 1.2.0(@types/react@19.1.0)(react@19.1.0)
@@ -452,6 +458,19 @@ packages:
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
 
+  '@radix-ui/react-checkbox@1.1.5':
+    resolution: {integrity: sha512-B0gYIVxl77KYDR25AY9EGe/G//ef85RVBIxQvK+m5pxAC7XihAc/8leMHhDvjvhDu02SBSb6BuytlWr/G7F3+g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -525,6 +544,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-label@2.1.3':
+    resolution: {integrity: sha512-zwSQ1NzSKG95yA0tvBMgv6XPHoqapJCcg9nsUBaQQ66iRBhZNhlpaQG2ERYYX4O4stkYFK5rxj5NsWfO9CS+Hg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-portal@1.1.5':
@@ -604,6 +636,24 @@ packages:
 
   '@radix-ui/react-use-layout-effect@1.1.1':
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.1':
+    resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3073,6 +3123,22 @@ snapshots:
 
   '@radix-ui/primitive@1.1.2': {}
 
+  '@radix-ui/react-checkbox@1.1.5(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.3(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.0.3(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.1.1(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.0)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.1(@types/react@19.1.0)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.0)(react@19.1.0)':
     dependencies:
       react: 19.1.0
@@ -3144,6 +3210,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.0
 
+  '@radix-ui/react-label@2.1.3(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.3(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.1(@types/react@19.1.0)
+
   '@radix-ui/react-portal@1.1.5(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.3(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -3202,6 +3277,19 @@ snapshots:
 
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.1.0)(react@19.1.0)':
     dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.0
+
+  '@radix-ui/react-use-previous@1.1.1(@types/react@19.1.0)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.0
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.1.0)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.0)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.0

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ export function App() {
         <Routes>
           <Route path="/" element={<IssueList />} />
           <Route path="/issues/:issueNumber" element={<IssueList />} />
+          <Route path="/issues/new" element={<IssueList />} />
         </Routes>
       </main>
     </>

--- a/src/api/issueApi.ts
+++ b/src/api/issueApi.ts
@@ -1,4 +1,4 @@
-import { Issue, IssueDetail } from '@type/githubTypes';
+import { CreateIssueParams, Issue, IssueDetail } from '@type/githubTypes';
 
 import { httpClient } from './httpClient';
 
@@ -8,4 +8,8 @@ export const getIssues = () => {
 
 export const getIssueDetail = (issueNumber: number) => {
   return httpClient.get<IssueDetail>(`/issues/${issueNumber}`);
+};
+
+export const createIssue = (params: CreateIssueParams) => {
+  return httpClient.post('/issues', params);
 };

--- a/src/api/labelApi.ts
+++ b/src/api/labelApi.ts
@@ -1,0 +1,7 @@
+import { Label } from '@type/githubTypes';
+
+import { httpClient } from './httpClient';
+
+export const getLabels = () => {
+  return httpClient.get<Label[]>('/labels');
+};

--- a/src/api/userApi.ts
+++ b/src/api/userApi.ts
@@ -1,0 +1,7 @@
+import { GitHubUser } from '@type/githubTypes';
+
+import { httpClient } from './httpClient';
+
+export const getUsers = () => {
+  return httpClient.get<GitHubUser[]>('/collaborators');
+};

--- a/src/components/IssueList.tsx
+++ b/src/components/IssueList.tsx
@@ -1,33 +1,38 @@
 import { getIssues } from '@api/issueApi';
+import { IssueCreateModal } from '@components/issue/IssueCreateModal';
 import { IssueDetailModal } from '@components/issue/IssueDetailModal';
 import { Skeleton } from '@shared/shadcn/ui/skeleton';
 import { Issue } from '@type/githubTypes';
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+
+import { Button } from '@/shared/shadcn/ui/button';
 
 import { IssueCard } from './IssueCard';
 
 export function IssueList() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { issueNumber } = useParams<{ issueNumber?: string }>();
+  const isCreating = location.pathname === '/issues/new';
+
   const [issues, setIssues] = useState<Issue[]>([]);
   const [loading, setLoading] = useState(true);
 
-  const navigate = useNavigate();
-  const { issueNumber } = useParams<{ issueNumber?: string }>();
+  const fetchIssues = async () => {
+    try {
+      const data = await getIssues();
+      setIssues(data);
+    } catch (e) {
+      console.error('Failed to fetch issues', e);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
-    const fetchIssues = async () => {
-      try {
-        const data = await getIssues();
-        setIssues(data);
-      } catch (e) {
-        console.error('Failed to fetch issues', e);
-      } finally {
-        setLoading(false);
-      }
-    };
-
     fetchIssues();
-  }, []);
+  }, [location.pathname]);
 
   const handleCardClick = (issueNumber: number) => {
     navigate(`/issues/${issueNumber}`);
@@ -37,33 +42,48 @@ export function IssueList() {
     navigate('/');
   };
 
-  if (loading) {
-    return (
-      <div className="space-y-4">
-        {[...Array(3)].map((_, i) => (
-          <Skeleton key={i} className="h-24 rounded-xl" />
-        ))}
-      </div>
-    );
-  }
-
   return (
     <div>
-      {issues.map((issue) => (
-        <div key={issue.id} onClick={() => handleCardClick(issue.number)}>
-          <IssueCard
-            title={issue.title}
-            number={issue.number}
-            user={issue.user.login}
-            state={issue.state}
-          />
+      <div className="mb-4 flex justify-end">
+        <Button onClick={() => navigate('/issues/new')}>+ 새 이슈 작성</Button>
+      </div>
+
+      {loading ? (
+        <div className="space-y-4">
+          {[...Array(3)].map((_, i) => (
+            <Skeleton key={i} className="h-24 rounded-xl" />
+          ))}
         </div>
-      ))}
+      ) : (
+        <>
+          {issues.map((issue) => (
+            <div key={issue.id} onClick={() => handleCardClick(issue.number)}>
+              <IssueCard
+                title={issue.title}
+                number={issue.number}
+                user={issue.user.login}
+                state={issue.state}
+              />
+            </div>
+          ))}
+        </>
+      )}
 
       {issueNumber && (
         <IssueDetailModal
           issueNumber={Number(issueNumber)}
           onClose={closeModal}
+        />
+      )}
+
+      {isCreating && (
+        <IssueCreateModal
+          open={true}
+          onClose={closeModal}
+          onCreated={() => {
+            fetchIssues();
+            closeModal();
+          }}
         />
       )}
     </div>

--- a/src/components/issue/IssueCreateModal/IssueCreateModal.tsx
+++ b/src/components/issue/IssueCreateModal/IssueCreateModal.tsx
@@ -1,0 +1,155 @@
+import { createIssue } from '@api/issueApi';
+import { getLabels } from '@api/labelApi';
+import { getUsers } from '@api/userApi';
+import { Button } from '@shared/shadcn/ui/button';
+import { Checkbox } from '@shared/shadcn/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@shared/shadcn/ui/dialog';
+import { Input } from '@shared/shadcn/ui/input';
+import { Textarea } from '@shared/shadcn/ui/textarea';
+import { CreateIssueParams, GitHubUser, Label } from '@type/githubTypes';
+import { useEffect, useState } from 'react';
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onCreated?: () => void;
+};
+
+export function IssueCreateModal({ open, onClose }: Props) {
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [labels, setLabels] = useState<Label[]>([]);
+  const [users, setUsers] = useState<GitHubUser[]>([]);
+  const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
+  const [selectedAssignees, setSelectedAssignees] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchMeta = async () => {
+      try {
+        const [labelRes, userRes] = await Promise.all([
+          getLabels(),
+          getUsers(),
+        ]);
+        setLabels(labelRes);
+        setUsers(userRes);
+      } catch (err) {
+        console.error('라벨 또는 유저 정보를 가져오는 데 실패했습니다.', err);
+      }
+    };
+    if (open) fetchMeta();
+  }, [open]);
+
+  const handleSubmit = async () => {
+    if (!title.trim()) return alert('제목을 입력해주세요.');
+    setLoading(true);
+    try {
+      const params: CreateIssueParams = {
+        title,
+        body,
+        labels: selectedLabels,
+        assignees: selectedAssignees,
+      };
+      await createIssue(params);
+      setTimeout(() => {
+        // 서버처리시간
+        onClose(); // TODO: 성공 메시지 띄우기
+      }, 2000);
+    } catch (err) {
+      console.error('이슈 생성 실패', err);
+      alert('이슈 생성 중 오류가 발생했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>새 이슈 작성</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <Input
+            placeholder="제목"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          <Textarea
+            placeholder="설명"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+          />
+
+          <div>
+            <h4 className="mb-2 text-sm font-semibold">라벨 선택</h4>
+            <div className="flex flex-wrap gap-2">
+              {labels.map((label) => (
+                <label
+                  key={label.id}
+                  className="flex items-center gap-1 text-sm"
+                >
+                  <Checkbox
+                    checked={selectedLabels.includes(label.name)}
+                    onCheckedChange={(checked) =>
+                      setSelectedLabels((prev) =>
+                        checked
+                          ? [...prev, label.name]
+                          : prev.filter((l) => l !== label.name)
+                      )
+                    }
+                  />
+                  <span
+                    className="rounded px-2 py-0.5"
+                    style={{ backgroundColor: `#${label.color}` }}
+                  >
+                    {label.name}
+                  </span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <h4 className="mb-2 text-sm font-semibold">담당자 선택</h4>
+            <div className="flex flex-wrap gap-2">
+              {users.map((user) => (
+                <label
+                  key={user.id}
+                  className="flex items-center gap-1 text-sm"
+                >
+                  <Checkbox
+                    checked={selectedAssignees.includes(user.login)}
+                    onCheckedChange={(checked) =>
+                      setSelectedAssignees((prev) =>
+                        checked
+                          ? [...prev, user.login]
+                          : prev.filter((u) => u !== user.login)
+                      )
+                    }
+                  />
+                  <img
+                    src={user.avatar_url}
+                    alt={user.login}
+                    className="h-5 w-5 rounded-full"
+                  />
+                  {user.login}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <Button onClick={handleSubmit} disabled={loading}>
+            {loading ? '생성 중...' : '이슈 생성'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/issue/IssueCreateModal/IssueCreateModal.tsx
+++ b/src/components/issue/IssueCreateModal/IssueCreateModal.tsx
@@ -1,8 +1,5 @@
 import { createIssue } from '@api/issueApi';
-import { getLabels } from '@api/labelApi';
-import { getUsers } from '@api/userApi';
 import { Button } from '@shared/shadcn/ui/button';
-import { Checkbox } from '@shared/shadcn/ui/checkbox';
 import {
   Dialog,
   DialogContent,
@@ -13,6 +10,9 @@ import { Input } from '@shared/shadcn/ui/input';
 import { Textarea } from '@shared/shadcn/ui/textarea';
 import { CreateIssueParams, GitHubUser, Label } from '@type/githubTypes';
 import { useEffect, useState } from 'react';
+
+import { MultiSelect } from '@/shared/MultiSelect';
+import { fetchMeta } from '@/utils/fetchMeta';
 
 type Props = {
   open: boolean;
@@ -30,19 +30,15 @@ export function IssueCreateModal({ open, onClose }: Props) {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    const fetchMeta = async () => {
-      try {
-        const [labelRes, userRes] = await Promise.all([
-          getLabels(),
-          getUsers(),
-        ]);
-        setLabels(labelRes);
-        setUsers(userRes);
-      } catch (err) {
-        console.error('라벨 또는 유저 정보를 가져오는 데 실패했습니다.', err);
-      }
-    };
-    if (open) fetchMeta();
+    if (!open) return;
+    fetchMeta()
+      .then(({ labels, users }) => {
+        setLabels(labels);
+        setUsers(users);
+      })
+      .catch((err) =>
+        console.error('라벨 또는 유저 정보를 가져오는 데 실패했습니다.', err)
+      );
   }, [open]);
 
   const handleSubmit = async () => {
@@ -57,7 +53,6 @@ export function IssueCreateModal({ open, onClose }: Props) {
       };
       await createIssue(params);
       setTimeout(() => {
-        // 서버처리시간
         onClose(); // TODO: 성공 메시지 띄우기
       }, 2000);
     } catch (err) {
@@ -89,60 +84,40 @@ export function IssueCreateModal({ open, onClose }: Props) {
 
           <div>
             <h4 className="mb-2 text-sm font-semibold">라벨 선택</h4>
-            <div className="flex flex-wrap gap-2">
-              {labels.map((label) => (
-                <label
-                  key={label.id}
-                  className="flex items-center gap-1 text-sm"
+            <MultiSelect
+              items={labels}
+              selectedItems={selectedLabels}
+              onChange={setSelectedLabels}
+              getKey={(label) => label.name}
+              renderLabel={(label) => (
+                <span
+                  className="rounded px-2 py-0.5"
+                  style={{ backgroundColor: `#${label.color}` }}
                 >
-                  <Checkbox
-                    checked={selectedLabels.includes(label.name)}
-                    onCheckedChange={(checked) =>
-                      setSelectedLabels((prev) =>
-                        checked
-                          ? [...prev, label.name]
-                          : prev.filter((l) => l !== label.name)
-                      )
-                    }
-                  />
-                  <span
-                    className="rounded px-2 py-0.5"
-                    style={{ backgroundColor: `#${label.color}` }}
-                  >
-                    {label.name}
-                  </span>
-                </label>
-              ))}
-            </div>
+                  {label.name}
+                </span>
+              )}
+            />
           </div>
 
           <div>
             <h4 className="mb-2 text-sm font-semibold">담당자 선택</h4>
-            <div className="flex flex-wrap gap-2">
-              {users.map((user) => (
-                <label
-                  key={user.id}
-                  className="flex items-center gap-1 text-sm"
-                >
-                  <Checkbox
-                    checked={selectedAssignees.includes(user.login)}
-                    onCheckedChange={(checked) =>
-                      setSelectedAssignees((prev) =>
-                        checked
-                          ? [...prev, user.login]
-                          : prev.filter((u) => u !== user.login)
-                      )
-                    }
-                  />
+            <MultiSelect
+              items={users}
+              selectedItems={selectedAssignees}
+              onChange={setSelectedAssignees}
+              getKey={(user) => user.login}
+              renderLabel={(user) => (
+                <>
                   <img
                     src={user.avatar_url}
                     alt={user.login}
                     className="h-5 w-5 rounded-full"
                   />
                   {user.login}
-                </label>
-              ))}
-            </div>
+                </>
+              )}
+            />
           </div>
 
           <Button onClick={handleSubmit} disabled={loading}>

--- a/src/components/issue/IssueCreateModal/index.ts
+++ b/src/components/issue/IssueCreateModal/index.ts
@@ -1,0 +1,1 @@
+export { IssueCreateModal } from './IssueCreateModal';

--- a/src/shared/MultiSelect/MultiSelect.tsx
+++ b/src/shared/MultiSelect/MultiSelect.tsx
@@ -1,0 +1,42 @@
+import { Checkbox } from '@shared/shadcn/ui/checkbox';
+
+type MultiSelectProps<T> = {
+  items: T[];
+  selectedItems: string[];
+  onChange: (selected: string[]) => void;
+  getKey: (item: T) => string;
+  renderLabel: (item: T) => React.ReactNode;
+};
+
+export function MultiSelect<T>({
+  items,
+  selectedItems,
+  onChange,
+  getKey,
+  renderLabel,
+}: MultiSelectProps<T>) {
+  const handleCheckedChange = (key: string, checked: boolean) => {
+    onChange(
+      checked ? [...selectedItems, key] : selectedItems.filter((k) => k !== key)
+    );
+  };
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {items.map((item) => {
+        const key = getKey(item);
+        return (
+          <label key={key} className="flex items-center gap-1 text-sm">
+            <Checkbox
+              checked={selectedItems.includes(key)}
+              onCheckedChange={(checked) =>
+                handleCheckedChange(key, Boolean(checked))
+              }
+            />
+            {renderLabel(item)}
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/shared/MultiSelect/index.ts
+++ b/src/shared/MultiSelect/index.ts
@@ -1,0 +1,1 @@
+export { MultiSelect } from './MultiSelect';

--- a/src/shared/shadcn/ui/checkbox.tsx
+++ b/src/shared/shadcn/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
+import { CheckIcon } from 'lucide-react';
+import * as React from 'react';
+
+import { cn } from '@/shared/lib/utils';
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        'peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/src/shared/shadcn/ui/input.tsx
+++ b/src/shared/shadcn/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import { cn } from '@/shared/lib/utils';
+
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/src/shared/shadcn/ui/label.tsx
+++ b/src/shared/shadcn/ui/label.tsx
@@ -1,0 +1,22 @@
+import * as LabelPrimitive from '@radix-ui/react-label';
+import * as React from 'react';
+
+import { cn } from '@/shared/lib/utils';
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Label };

--- a/src/shared/shadcn/ui/textarea.tsx
+++ b/src/shared/shadcn/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import { cn } from '@/shared/lib/utils';
+
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/src/types/githubTypes.ts
+++ b/src/types/githubTypes.ts
@@ -50,3 +50,10 @@ export interface GitHubRateLimit {
     reset: number;
   };
 }
+
+export interface CreateIssueParams {
+  title: string;
+  body?: string;
+  labels?: string[];
+  assignees?: string[];
+}

--- a/src/utils/fetchMeta.ts
+++ b/src/utils/fetchMeta.ts
@@ -1,0 +1,14 @@
+import { getLabels } from '@api/labelApi';
+import { getUsers } from '@api/userApi';
+import { GitHubUser, Label } from '@type/githubTypes';
+
+export async function fetchMeta(): Promise<{
+  labels: Label[];
+  users: GitHubUser[];
+}> {
+  const [labelRes, userRes] = await Promise.all([getLabels(), getUsers()]);
+  return {
+    labels: labelRes,
+    users: userRes,
+  };
+}


### PR DESCRIPTION
## 관련 이슈 번호

Resolves #12 

## 핵심 변경 사항 및 이유

- GitHub 이슈 생성 기능이 구현되었습니다.
- 사용자는 이슈의 제목, 설명, 라벨, 담당자를 입력하여 새로운 이슈를 생성할 수 있습니다.
- 이슈 생성 시 GitHub REST API를 사용하며, 모달 방식의 UX로 구현되어 사용성이 향상되었습니다.
- 라벨/담당자 선택은 재사용 가능한 MultiSelect 컴포넌트를 사용합니다.
- 관련 API 호출은 `fetchMeta` 유틸 함수로 분리하여 유지보수성을 높였습니다.

## 이외 기타 변경 사항

- 이슈 생성 후 자동으로 목록을 갱신합니다.
- UI 구성에 필요한 ShadCN UI 컴포넌트들(input, label, checkbox 등)을 추가하였습니다.
- /issues/new 경로를 통해 이슈 생성 모달 접근이 가능하며, 기존 이슈 목록 페이지에 '이슈 생성' 버튼이 추가되었습니다.

## PR 시 참고 사항

- 향후 Octokit 기반 API 클라이언트로 리팩토링하여 API 호출을 일관되게 관리할 계획입니다.


## 관련 스크린샷

<!-- UI 변경 사항이 있다면 Before/After 스크린샷을 첨부해 주세요. -->

![image](https://github.com/user-attachments/assets/2b3e3774-72b7-43a6-8735-597e756e37e6)

